### PR TITLE
Close context in Source.Open when plugin stops

### DIFF
--- a/source.go
+++ b/source.go
@@ -37,7 +37,8 @@ type Source interface {
 
 	// Open is called after Configure to signal the plugin it can prepare to
 	// start producing records. If needed, the plugin should open connections in
-	// this function.
+	// this function. The context passed to Open will be cancelled once the
+	// plugin receives a stop signal from Conduit.
 	Open(context.Context, Position) error
 
 	// Read returns a new Record and is supposed to block until there is either
@@ -87,6 +88,7 @@ type sourcePluginAdapter struct {
 	// readDone will be closed after runRead stops running.
 	readDone chan struct{}
 
+	openCancel context.CancelFunc
 	readCancel context.CancelFunc
 	ackCancel  context.CancelFunc
 	t          *tomb.Tomb
@@ -98,6 +100,7 @@ func (a *sourcePluginAdapter) Configure(ctx context.Context, req cpluginv1.Sourc
 }
 
 func (a *sourcePluginAdapter) Start(ctx context.Context, req cpluginv1.SourceStartRequest) (cpluginv1.SourceStartResponse, error) {
+	ctx, a.openCancel = context.WithCancel(ctx)
 	err := a.impl.Open(ctx, req.Position)
 	return cpluginv1.SourceStartResponse{}, err
 }
@@ -222,8 +225,10 @@ func (a *sourcePluginAdapter) runAck(ctx context.Context, stream cpluginv1.Sourc
 }
 
 func (a *sourcePluginAdapter) Stop(ctx context.Context, req cpluginv1.SourceStopRequest) (cpluginv1.SourceStopResponse, error) {
-	a.readCancel() // stop reading new messages
-	<-a.readDone   // wait for read to actually stop running
+	// stop reading new messages
+	a.openCancel()
+	a.readCancel()
+	<-a.readDone // wait for read to actually stop running
 	if atomic.LoadInt32(&a.openAcks) == 0 {
 		// we aren't waiting for any further acks, let's stop the ack goroutine as well
 		a.ackCancel()


### PR DESCRIPTION
Moving commit from Conduit to the SDK: https://github.com/ConduitIO/conduit/pull/230/commits/f8d99d9367473244325b624dfbf7ed9a35427787

This change makes sure that the context passed to `Open` will be closed once `Stop` is called. This is useful because `Open` might be used to spawn background jobs that need to be notified when the plugin should stop. Otherwise the user would need to detect it in the `Read` function.